### PR TITLE
Footnotes for Stack<T> and non-generic Stack regarding round-tripping

### DIFF
--- a/docs/standard/serialization/system-text-json/supported-collection-types.md
+++ b/docs/standard/serialization/system-text-json/supported-collection-types.md
@@ -46,7 +46,9 @@ The following sections are organized by namespace and show which types are suppo
 | <xref:System.Collections.IList>           | ✔️           | ✔️              |
 | <xref:System.Collections.Queue>           | ✔️           | ✔️              |
 | <xref:System.Collections.SortedList>      | ✔️           | ✔️              |
-| <xref:System.Collections.Stack>           | ✔️           | ✔️              |
+| <xref:System.Collections.Stack> \*        | ✔️           | ✔️              |
+
+\* See [Support round trip for Stack](converters-how-to.md#support-round-trip-for-stackt).
 
 ## System.Collections.Generic namespace
 
@@ -71,11 +73,13 @@ The following sections are organized by namespace and show which types are suppo
 | <xref:System.Collections.Generic.SortedDictionary%602> \* | ✔️           | ✔️              |
 | <xref:System.Collections.Generic.SortedList%602> \*       | ✔️           | ✔️              |
 | <xref:System.Collections.Generic.SortedSet%601>           | ✔️           | ✔️              |
-| <xref:System.Collections.Generic.Stack%601>               | ✔️           | ✔️              |
+| <xref:System.Collections.Generic.Stack%601> \*\*\*        | ✔️           | ✔️              |
 
 \* See [Supported key types](#supported-key-types).
 
 \*\* See the following section on `IAsyncEnumerable<T>`.
+
+\*\*\* See [Support round trip for Stack\<T>](converters-how-to.md#support-round-trip-for-stackt).
 
 ### IAsyncEnumerable\<T>
 


### PR DESCRIPTION
Added footnotes regarding stack round-tripping for System.Collections.Stack and System.Collections.Generic.Stack<T> in the same manner as the already present footnotes for ImmutableStack and ConcurrentStack.

Personally, the footnote for the non-generic System.Collections.Stack feels a bit awkward to me, as the referred chapter about stack round-tripping is featuring the generic Stack<T> in its title.

## Summary

Copied and applied the "_See [Support round trip for Stack<T>](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to#support-round-trip-for-stackt)._" footnote to the table with the `System.Collections.Generic.Stack<T>` collection and the table with the `System.Collections.Stack` collection.

For the non-generic Stack collection type, i elected to slightly change the footnote text from "_See Support round trip for Stack<T>._" to "_See Support round trip for Stack._". Let me know if you prefer the original footnote text here, and i will adjust the PR.